### PR TITLE
Fix Editor sometimes crashes when entering Play Mode

### DIFF
--- a/Scripts/UIParticle.cs
+++ b/Scripts/UIParticle.cs
@@ -378,7 +378,7 @@ namespace Coffee.UIExtensions
 #if UNITY_EDITOR
                 EditorApplication.delayCall += () =>
                 {
-                    if (!this || !gameObject || !transform) return;
+                    if (!this || !gameObject || !transform || Application.isPlaying) return;
                     transform.localScale = Vector3.one;
                     m_ResetScaleOnEnable = false;
                     EditorUtility.SetDirty(this);


### PR DESCRIPTION
Version: Unity 2021.3.31 (Windows 11 x64)

There are some particle prefabs in the project that were created using version 3.x. When the editor enters Play Mode, the deserialization operation will cause the editor crash.

	Managed Stacktrace:
=================================================================
	  at <unknown> <0xffffffff>
	  at UnityEngine.Transform:set_localScale_Injected <0x00153>
	  at UnityEngine.Transform:set_localScale <0x0007a>
	  at Coffee.UIExtensions.UIParticle:<UnityEngine.ISerializationCallbackReceiver.OnAfterDeserialize>b__83_0 <0x0025a>
	  at UnityEditor.EditorApplication:Internal_CallDelayFunctions <0x002df>
	  at System.Object:runtime_invoke_void <0x00184>